### PR TITLE
#170301423 get expense endpoint 

### DIFF
--- a/src/helper/queryHelper.js
+++ b/src/helper/queryHelper.js
@@ -24,7 +24,6 @@ export default async (queryParams, queryKeys, currentPage) => {
       error: "Invalid query param(s)"
     };
   }
-
   const data = await Expense.find(queryParams)
     .skip(expPerPage * currentPage - expPerPage)
     .limit(expPerPage);

--- a/src/helper/queryHelper.js
+++ b/src/helper/queryHelper.js
@@ -1,7 +1,7 @@
 import Expense from "../model/expense";
 
 export default async (queryParams, queryKeys, currentPage) => {
-  const expPerPage = 9;
+  const expPerPage = queryParams.limit ? Number(queryParams.limit): 0;
   const requiredParams = [
     "status",
     "uuid",
@@ -12,9 +12,10 @@ export default async (queryParams, queryKeys, currentPage) => {
     "employee"
   ];
 
-  // eliminate page
-  const newArray = queryKeys.filter(value => value !== "page");
+  // eliminate page and limit
+  const newArray = queryKeys.filter(value => (value !== "page" && value !== "limit"));  
   delete queryParams.page;
+  delete queryParams.limit;
 
   const isValidParam = newArray.every(key => requiredParams.includes(key));
   if (!isValidParam) {
@@ -28,9 +29,10 @@ export default async (queryParams, queryKeys, currentPage) => {
     .skip(expPerPage * currentPage - expPerPage)
     .limit(expPerPage);
   const count = await Expense.countDocuments(queryParams);
+  const pages = expPerPage === 0 ? 1: Math.ceil(count / expPerPage)
   return {
     status: 200,
-    pages: Math.ceil(count / expPerPage),
+    pages,
     count,
     data
   };


### PR DESCRIPTION
#### What does this PR do?
- Allows passing `limit` as a query param
#### Description of Task to be completed
- When a limit param is not provided, Users can fetch all expenses. However, When limit param is provided, Users can only fetch the paginated items(by the passed limit)
#### How should this be manually tested?
-N/A
#### Any background context you want to provide?
-N/A
#### What are the relevant pivotal tracker stories?
[#170301423](https://www.pivotaltracker.com/story/show/170301423)

#### Screenshots (if appropriate)
NA